### PR TITLE
Added a device name option in Touch.Server/Main.cs

### DIFF
--- a/Touch.Server/Main.cs
+++ b/Touch.Server/Main.cs
@@ -175,7 +175,7 @@ class SimpleListener
 							procArgs.Append ("--sdkroot ").Append (sdk_root);
 						procArgs.Append (" --launchdev ");
 						procArgs.Append (launchdev);
-						procArgs.AppendFormat (" --devName={0} ", deviceName);
+						procArgs.AppendFormat (" --devname={0} ", deviceName);
 						procArgs.Append (" -argument=-connection-mode -argument=none");
 						procArgs.Append (" -argument=-app-arg:-autostart");
 						procArgs.Append (" -argument=-app-arg:-autoexit");


### PR DESCRIPTION
Hi Sebastien,

I have included a device name parameter in var os in Touch.Server/Main.cs.  This will allow users to pass device name to Touch.Unit. This makes the user execute test in multiple devices attached to a mac. Previously, if multiple devices are attached, tests used to execute that many times in a single device. 

Please verify. It would be great if you could also include this in your Touch.Unit repo

Best,
Gouri
