### PR TITLE
Add a HttpTextWriter that can send logs over http.

### DIFF
--- a/NUnitLite/TouchRunner/HttpTextWriter.cs
+++ b/NUnitLite/TouchRunner/HttpTextWriter.cs
@@ -1,0 +1,100 @@
+// HttpTextWriter.cs: Class to report test results using http requests
+//
+// Authors:
+//	Rolf Bjarne Kvinge <rolf@xamarin.com>
+//
+// Copyright 2016 Xamarin Inc.
+//
+
+using System;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+#if __UNIFIED__
+using Foundation;
+#else
+using MonoTouch.Foundation;
+#endif
+
+namespace MonoTouch.NUnit {
+	class HttpTextWriter : TextWriter
+	{
+		public string HostName;
+		public int Port;
+
+		TaskCompletionSource<bool> finished = new TaskCompletionSource<bool> ();
+		TaskCompletionSource<bool> closed = new TaskCompletionSource<bool> ();
+		StringBuilder log = new StringBuilder ();
+
+		public Task FinishedTask {
+			get {
+				return finished.Task;
+			}
+		}
+
+		public override Encoding Encoding {
+			get {
+				return Encoding.UTF8;
+			}
+		}
+
+		public override void Close ()
+		{
+			closed.SetResult (true);
+			Task.Run (async () =>
+			{
+				await finished.Task;
+				base.Close ();
+			});
+		}
+
+		Task SendData (string action, string uploadData)
+		{
+			var url = NSUrl.FromString ("http://" + HostName + ":" + Port + "/" + action);
+			var request = new NSMutableUrlRequest (url);
+			request.HttpMethod = "POST";
+			return NSUrlSession.SharedSession.CreateUploadTaskAsync (request, NSData.FromString (uploadData));
+		}
+
+		async void SendThread ()
+		{
+			try {
+				await SendData ("Start", "");
+				await closed.Task;
+				await SendData ("Finish", log.ToString ());
+			} catch (Exception ex) {
+				Console.WriteLine ("HttpTextWriter failed: {0}", ex);
+			} finally {
+				finished.SetResult (true);				
+			}
+		}
+
+		public void Open ()
+		{
+			new Thread (SendThread)
+			{
+				IsBackground = true,
+			}.Start ();
+		}
+
+		public override void Write (char value)
+		{
+			Console.Out.Write (value);
+			log.Append (value);
+		}
+
+		public override void Write (char [] buffer)
+		{
+			Console.Out.Write (buffer);
+			log.Append (buffer);
+		}
+	
+		public override void WriteLine (string value)
+		{
+			Console.Out.WriteLine (value);
+			log.AppendLine (value);
+		}
+	}
+}

--- a/NUnitLite/TouchRunner/TouchOptions.cs
+++ b/NUnitLite/TouchRunner/TouchOptions.cs
@@ -48,6 +48,7 @@ namespace MonoTouch.NUnit.UI {
 			EnableNetwork = defaults.BoolForKey ("network.enabled");
 			HostName = defaults.StringForKey ("network.host.name");
 			HostPort = (int)defaults.IntForKey ("network.host.port");
+			Transport = defaults.StringForKey ("network.transport");
 			SortNames = defaults.BoolForKey ("display.sort");
 			
 			bool b;
@@ -64,13 +65,16 @@ namespace MonoTouch.NUnit.UI {
 				HostPort = i;
 			if (bool.TryParse (Environment.GetEnvironmentVariable ("NUNIT_SORTNAMES"), out b))
 				SortNames = b;
+			if (!string.IsNullOrEmpty (Environment.GetEnvironmentVariable ("NUNIT_TRANSPORT")))
+				Transport = Environment.GetEnvironmentVariable ("NUNIT_TRANSPORT");
 
 			var os = new OptionSet () {
 				{ "autoexit", "If the app should exit once the test run has completed.", v => TerminateAfterExecution = true },
 				{ "autostart", "If the app should automatically start running the tests.", v => AutoStart = true },
 				{ "hostname=", "Comma-separated list of host names or IP address to (try to) connect to", v => HostName = v },
-				{ "hostport=", "TCP port to connect to.", v => HostPort = int.Parse (v) },
+				{ "hostport=", "HTTP/TCP port to connect to.", v => HostPort = int.Parse (v) },
 				{ "enablenetwork", "Enable the network reporter.", v => EnableNetwork = true },
+				{ "transport=", "Select transport method. Either TCP (default) or HTTP.", v => Transport = v },
 			};
 			
 			try {
@@ -90,6 +94,8 @@ namespace MonoTouch.NUnit.UI {
 		
 		public bool TerminateAfterExecution { get; set; }
 		
+		public string Transport { get; set; } = "TCP";
+
 		public bool ShowUseNetworkLogger {
 			get { return (EnableNetwork && !String.IsNullOrWhiteSpace (HostName) && (HostPort > 0)); }
 		}


### PR DESCRIPTION
There is no public API to create raw sockets with watchOS, so
we can't use Tcp directly, thus the need for using Http.