### PR TITLE
Tweak test output a bit to optionally name a test when it starts.

### DIFF
--- a/NUnitLite/TouchRunner/TouchRunner.cs
+++ b/NUnitLite/TouchRunner/TouchRunner.cs
@@ -80,6 +80,8 @@ namespace MonoTouch.NUnit.UI {
 			set { TouchOptions.Current.TerminateAfterExecution = value; }
 		}
 
+		public bool PrintTestStart { get; set; }
+
 		List<Assembly> assemblies = new List<Assembly> ();
 		List<string> fixtures;
 
@@ -299,7 +301,9 @@ namespace MonoTouch.NUnit.UI {
 		{
 			if (test is TestSuite) {
 				Writer.WriteLine ();
-				Writer.WriteLine (test.Name);
+				Writer.WriteLine ("[START] {0}", test.Name);
+			} else if (PrintTestStart) {
+				Writer.WriteLine ("\t[START] {0}.{1}", test.FixtureType.Name, test.Name);
 			}
 		}
 
@@ -313,7 +317,7 @@ namespace MonoTouch.NUnit.UI {
 
 				string name = result.Test.Name;
 				if (!String.IsNullOrEmpty (name))
-					Writer.WriteLine ("{0} : {1} ms", name, result.Duration.TotalMilliseconds);
+					Writer.WriteLine ("[DONE] {0} : {1} ms", name, result.Duration.TotalMilliseconds);
 			} else {
 				if (result.IsSuccess ()) {
 					Writer.Write ("\t[PASS] ");


### PR DESCRIPTION
This makes it easier to figure out crashing tests, since it will
be the last one that's printed.
