### PR TITLE
wait longer as some tools take a while to exit

### DIFF
--- a/Touch.Server/Main.cs
+++ b/Touch.Server/Main.cs
@@ -347,8 +347,8 @@ class SimpleListener {
 			}
 			
 			var result = listener.Start ();
-			if (proc != null && !proc.WaitForExit (10000 /* wait another 10 seconds for mtouch to finish as well */))
-				Console.WriteLine ("mtouch didn't complete within 10s of the simulator app exiting. Touch.Server will exit anyway.");
+			if (proc != null && !proc.WaitForExit (30000 /* wait another 30 seconds for mtouch to finish as well */))
+				Console.WriteLine ("mtouch didn't complete within 30s of the simulator app exiting. Touch.Server will exit anyway.");
 			// Wait up to 2 seconds to receive the last of the error/output data. This will only be received *after*
 			// mtouch has exited.
 			lastErrorDataReceived.WaitOne (2000);


### PR DESCRIPTION
This seems to make our xcode8 based tests fully reliable on wrench.
It must be helping us bypass the bug that causes the deadlock if we
wait for the process to gracefully exit