### PR TITLE
Add xml output support

### DIFF
--- a/NUnitLite/TouchRunner/TouchOptions.cs
+++ b/NUnitLite/TouchRunner/TouchOptions.cs
@@ -46,6 +46,7 @@ namespace MonoTouch.NUnit.UI {
 			TerminateAfterExecution = defaults.BoolForKey ("execution.autoexit");
 			AutoStart = defaults.BoolForKey ("execution.autostart");
 			EnableNetwork = defaults.BoolForKey ("network.enabled");
+			EnableXml = defaults.BoolForKey ("xml.enabled");
 			HostName = defaults.StringForKey ("network.host.name");
 			HostPort = (int)defaults.IntForKey ("network.host.port");
 			Transport = defaults.StringForKey ("network.transport");
@@ -67,6 +68,8 @@ namespace MonoTouch.NUnit.UI {
 				SortNames = b;
 			if (!string.IsNullOrEmpty (Environment.GetEnvironmentVariable ("NUNIT_TRANSPORT")))
 				Transport = Environment.GetEnvironmentVariable ("NUNIT_TRANSPORT");
+			if (bool.TryParse (Environment.GetEnvironmentVariable ("NUNIT_ENABLE_XML_OUTPUT"), out b))
+				EnableXml = b;
 
 			var os = new OptionSet () {
 				{ "autoexit", "If the app should exit once the test run has completed.", v => TerminateAfterExecution = true },
@@ -75,6 +78,7 @@ namespace MonoTouch.NUnit.UI {
 				{ "hostport=", "HTTP/TCP port to connect to.", v => HostPort = int.Parse (v) },
 				{ "enablenetwork", "Enable the network reporter.", v => EnableNetwork = true },
 				{ "transport=", "Select transport method. Either TCP (default) or HTTP.", v => Transport = v },
+				{ "enablexml", "Enable the xml reported.", v => EnableXml = false },
 			};
 			
 			try {
@@ -85,6 +89,8 @@ namespace MonoTouch.NUnit.UI {
 		}
 		
 		private bool EnableNetwork { get; set; }
+
+		public bool EnableXml { get; set; }
 		
 		public string HostName { get; private set; }
 		

--- a/NUnitLite/TouchRunner/TouchRunner.cs
+++ b/NUnitLite/TouchRunner/TouchRunner.cs
@@ -216,6 +216,7 @@ namespace MonoTouch.NUnit.UI {
 						Console.WriteLine ("[{0}] Sending '{1}' results to {2}:{3}", now, message, hostname, options.HostPort);
 						try {
 							WriterFinishedTask = null;
+							TextWriter defaultWriter = null;
 							switch (options.Transport) {
 							case "HTTP":
 								var w = new HttpTextWriter ()
@@ -224,15 +225,21 @@ namespace MonoTouch.NUnit.UI {
 									Port = options.HostPort,
 								};
 								w.Open ();
-								Writer = w;
+								defaultWriter = w;
 								WriterFinishedTask = w.FinishedTask;
 								break;
 							default:
 								Console.WriteLine ("Unknown transport '{0}': switching to default (TCP)", options.Transport);
 								goto case "TCP";
 							case "TCP":
-								Writer = new TcpTextWriter (hostname, options.HostPort);
+								defaultWriter = new TcpTextWriter (hostname, options.HostPort);
 								break;
+							}
+							if (options.EnableXml) {
+								Writer = new NUnitOutputTextWriter (
+									this, defaultWriter, new NUnitLite.Runner.NUnit2XmlOutputWriter (DateTime.UtcNow));
+							} else {
+								Writer = defaultWriter;
 							}
 						}
 						catch (Exception ex) {


### PR DESCRIPTION
Users can either pass and option or set a env var to state that they want the logs to use the nunit xml format. This is useful in those cases when the  output wants to be parsed (example: jenkins bots). 