### PR TITLE
[TouchRunner] Don't auto-exit if we couldn't connect to the test runner.

### DIFF
--- a/NUnitLite/TouchRunner/TouchRunner.cs
+++ b/NUnitLite/TouchRunner/TouchRunner.cs
@@ -53,6 +53,7 @@ namespace MonoTouch.NUnit.UI {
 	public abstract class BaseTouchRunner : ITestListener {
 		TestSuite suite = new TestSuite (String.Empty);
 		ITestFilter filter = TestFilter.Empty;
+		bool connection_failure;
 
 		public int PassedCount { get; private set; }
 		public int FailedCount { get; private set; }
@@ -76,7 +77,7 @@ namespace MonoTouch.NUnit.UI {
 		}
 
 		public bool TerminateAfterExecution {
-			get { return TouchOptions.Current.TerminateAfterExecution; }
+			get { return TouchOptions.Current.TerminateAfterExecution && !connection_failure; }
 			set { TouchOptions.Current.TerminateAfterExecution = value; }
 		}
 
@@ -253,6 +254,7 @@ namespace MonoTouch.NUnit.UI {
 								Writer = defaultWriter;
 							}
 						} catch (Exception ex) {
+							connection_failure = true;
 							if (!ShowConnectionErrorAlert (hostname, options.HostPort, ex))
 								return false;
 


### PR DESCRIPTION
Extensions will automatically re-launch if they exit manually (or if they
crash), which means that every time a test run from an extension terminates,
iOS will re-launch it.

Unfortunately iOS will launch the extension with the same environment
variables, thus configuring the process to autorun / autoexit, which leads to
an infinite number of test runs (except that iOS detects extensions that
frequently exits and invalidates them after a while).

Fortunately, this second time we won't be able to connect to the test runner, so
we can use that to break the cycle.