### PR TITLE
[Touch.Server] Add ability to skip the header added to the log file

### DIFF
--- a/NUnitLite/TouchRunner/TouchOptions.cs
+++ b/NUnitLite/TouchRunner/TouchOptions.cs
@@ -70,6 +70,8 @@ namespace MonoTouch.NUnit.UI {
 				Transport = Environment.GetEnvironmentVariable ("NUNIT_TRANSPORT");
 			if (bool.TryParse (Environment.GetEnvironmentVariable ("NUNIT_ENABLE_XML_OUTPUT"), out b))
 				EnableXml = b;
+			if (bool.TryParse (Environment.GetEnvironmentVariable ("NUNIT_SKIP_LOG_HEADER"), out b))
+			    SkipLogHeader = b;
 
 			var os = new OptionSet () {
 				{ "autoexit", "If the app should exit once the test run has completed.", v => TerminateAfterExecution = true },
@@ -79,6 +81,7 @@ namespace MonoTouch.NUnit.UI {
 				{ "enablenetwork", "Enable the network reporter.", v => EnableNetwork = true },
 				{ "transport=", "Select transport method. Either TCP (default) or HTTP.", v => Transport = v },
 				{ "enablexml", "Enable the xml reported.", v => EnableXml = false },
+				{ "skiplogheader", "Do not write extra device related information to the logs (default: false)", v => SkipLogHeader = true },
 			};
 			
 			try {
@@ -91,6 +94,8 @@ namespace MonoTouch.NUnit.UI {
 		private bool EnableNetwork { get; set; }
 
 		public bool EnableXml { get; set; }
+
+		public bool SkipLogHeader { get; set; }
 		
 		public string HostName { get; private set; }
 		

--- a/NUnitLite/TouchRunner/TouchRunner.cs
+++ b/NUnitLite/TouchRunner/TouchRunner.cs
@@ -278,15 +278,16 @@ namespace MonoTouch.NUnit.UI {
 				}
 			}
 
-			Writer.WriteLine ("[Runner executing:\t{0}]", message);
-			Writer.WriteLine ("[MonoTouch Version:\t{0}]", Constants.Version);
-			Writer.WriteLine ("[Assembly:\t{0}.dll ({1} bits)]", typeof (NSObject).Assembly.GetName ().Name, IntPtr.Size * 8);
-			Writer.WriteLine ("[GC:\t{0}]", GC.MaxGeneration == 0 ? "Boehm": "sgen");
-			WriteDeviceInformation (Writer);
-			Writer.WriteLine ("[Device Locale:\t{0}]", NSLocale.CurrentLocale.Identifier);
-			Writer.WriteLine ("[Device Date/Time:\t{0}]", now); // to match earlier C.WL output
+			var writer = options.SkipLogHeader ? Console.Out : Writer;
+			writer.WriteLine ("[Runner executing:\t{0}]", message);
+			writer.WriteLine ("[MonoTouch Version:\t{0}]", Constants.Version);
+			writer.WriteLine ("[Assembly:\t{0}.dll ({1} bits)]", typeof (NSObject).Assembly.GetName ().Name, IntPtr.Size * 8);
+			writer.WriteLine ("[GC:\t{0}]", GC.MaxGeneration == 0 ? "Boehm": "sgen");
+			WriteDeviceInformation (writer);
+			writer.WriteLine ("[Device Locale:\t{0}]", NSLocale.CurrentLocale.Identifier);
+			writer.WriteLine ("[Device Date/Time:\t{0}]", now); // to match earlier C.WL output
 
-			Writer.WriteLine ("[Bundle:\t{0}]", NSBundle.MainBundle.BundleIdentifier);
+			writer.WriteLine ("[Bundle:\t{0}]", NSBundle.MainBundle.BundleIdentifier);
 			// FIXME: add data about how the app was compiled (e.g. ARMvX, LLVM, GC and Linker options)
 			PassedCount = 0;
 			IgnoredCount = 0;

--- a/Touch.Server/Main.cs
+++ b/Touch.Server/Main.cs
@@ -44,6 +44,7 @@ class SimpleListener {
 	string LogPath { get; set; }
 	string LogFile { get; set; }
 	bool AutoExit { get; set; }
+	bool SkipLogHeader { get; set; }
 
 	public bool WaitForConnection (TimeSpan ts)
 	{
@@ -107,12 +108,14 @@ class SimpleListener {
 		connected.Set ();
 
 		using (FileStream fs = File.OpenWrite (logfile)) {
-			// a few extra bits of data only available from this side
-			string header = String.Format ("[Local Date/Time:\t{1}]{0}[Remote Address:\t{2}]{0}", 
-				Environment.NewLine, DateTime.Now, remote);
-			byte[] array = Encoding.UTF8.GetBytes (header);
-			fs.Write (array, 0, array.Length);
-			fs.Flush ();
+			if (!SkipLogHeader) {
+				// a few extra bits of data only available from this side
+				string header = String.Format ("[Local Date/Time:\t{1}]{0}[Remote Address:\t{2}]{0}",
+					Environment.NewLine, DateTime.Now, remote);
+				byte[] array = Encoding.UTF8.GetBytes (header);
+				fs.Write (array, 0, array.Length);
+				fs.Flush ();
+			}
 			// now simply copy what we receive
 			int i;
 			int total = 0;
@@ -150,6 +153,7 @@ class SimpleListener {
 		string port = null;
 		string log_path = ".";
 		string log_file = null;
+		bool skipLogHeader = false;
 		string launchdev = null;
 		string launchsim = null;
 		bool autoexit = false;
@@ -166,6 +170,7 @@ class SimpleListener {
 			{ "port", "TCP port to listen (default: Any)", v => port = v },
 			{ "logpath", "Path to save the log files (default: .)", v => log_path = v },
 			{ "logfile=", "Filename to save the log to (default: automatically generated)", v => log_file = v },
+			{ "skiplogheader", "Do not write the time and remote address to the log (default: false)", v => skipLogHeader = true },
 			{ "launchdev=", "Run the specified app on a device (specify using bundle identifier)", v => launchdev = v },
 			{ "launchsim=", "Run the specified app on the simulator (specify using path to *.app directory)", v => launchsim = v },
 			{ "autoexit", "Exit the server once a test run has completed (default: false)", v => autoexit = true },
@@ -193,6 +198,7 @@ class SimpleListener {
 			
 			listener.LogPath = log_path ?? ".";
 			listener.LogFile = log_file;
+			listener.SkipLogHeader = skipLogHeader;
 			listener.AutoExit = autoexit;
 			listener.Initialize ();
 			


### PR DESCRIPTION
VSTS needs the output to be a valid xml file. We can't add arbitrary
statements to it otherwise it will fail to parse.

This is also useful for Jenkins.