### PR TITLE
[TouchRunner] Print something before exiting.

### DIFF
--- a/NUnitLite/TouchRunner/TouchRunner.cs
+++ b/NUnitLite/TouchRunner/TouchRunner.cs
@@ -109,6 +109,7 @@ namespace MonoTouch.NUnit.UI {
 		protected virtual void TerminateWithSuccess ()
 		{
 			// For WatchOS we're terminating the extension, not the watchos app itself.
+			Console.WriteLine ("Exiting test run with success");
 			exit (0);
 		}
 


### PR DESCRIPTION
This might help us narrow down https://bugzilla.xamarin.com/show_bug.cgi?id=56162.