### PR TITLE
[TouchRunner] do not use FinallyDelegate in Runner, because it requires remoting API to be available

### DIFF
--- a/NUnitLite/TouchRunner/TouchRunner.cs
+++ b/NUnitLite/TouchRunner/TouchRunner.cs
@@ -445,7 +445,7 @@ namespace MonoTouch.NUnit.UI {
 			TestExecutionContext current = TestExecutionContext.CurrentContext;
 			current.WorkDirectory = Environment.CurrentDirectory;
 			current.Listener = this;
-			WorkItem wi = test.CreateWorkItem (filter, new FinallyDelegate ());
+			WorkItem wi = test.CreateWorkItem (filter, null);
 			wi.Execute (current);
 			Result = wi.Result;
 			return Result;


### PR DESCRIPTION
depends on https://github.com/mono/NUnitLite/pull/7