### PR TITLE
Improve logging for failed TCP connections due to hostname

### DIFF
--- a/NUnitLite/TouchRunner/TouchRunner.cs
+++ b/NUnitLite/TouchRunner/TouchRunner.cs
@@ -212,7 +212,7 @@ namespace MonoTouch.NUnit.UI {
 								evt.Set ();
 							} catch (Exception e) {
 								lock (lock_obj) {
-									Console.WriteLine ("TCP connection failed when selecting 'hostname': {0}", e);
+									Console.WriteLine ("TCP connection failed when selecting 'hostname': {0} and 'port': {1}. {2}", name, port, e);
 									failures++;
 									if (failures == names.Length)
 										evt.Set ();

--- a/NUnitLite/TouchRunner/TouchRunner.cs
+++ b/NUnitLite/TouchRunner/TouchRunner.cs
@@ -210,8 +210,9 @@ namespace MonoTouch.NUnit.UI {
 										result = name;
 								}
 								evt.Set ();
-							} catch (Exception) {
+							} catch (Exception e) {
 								lock (lock_obj) {
+									Console.WriteLine ("TCP connection failed when selecting 'hostname': {0}", e);
 									failures++;
 									if (failures == names.Length)
 										evt.Set ();
@@ -266,8 +267,10 @@ namespace MonoTouch.NUnit.UI {
 							goto case "TCP";
 						case "TCP":
 							hostname = SelectHostName (options.HostName.Split (','), options.HostPort);
-							if (string.IsNullOrEmpty (hostname))
+							if (string.IsNullOrEmpty (hostname)) {
+								Console.WriteLine ("Couldn't establish a TCP connection with any of the hostnames: {0}", options.HostName);
 								break;
+							}
 							Console.WriteLine ("[{0}] Sending '{1}' results to {2}:{3}", now, message, hostname, options.HostPort);
 							defaultWriter = new TcpTextWriter (hostname, options.HostPort);
 							break;


### PR DESCRIPTION
The new improved logging adds this bit of info to the run logs:

```
2019-08-14 15:21:04.592 dont link[7054:2130112] TCP connection failed when selecting 'hostname': System.Net.Sockets.SocketException (0x80004005): No route to host
  at System.Net.Sockets.TcpClient..ctor (System.String hostname, System.Int32 port) [0x0006d] in /Users/vidondai/Documents/xi-xcode11/xamarin-macios/external/mono/mcs/class/referencesource/System/net/System/Net/Sockets/TCPClient.cs:122 
  at MonoTouch.NUnit.UI.BaseTouchRunner+<>c__DisplayClass55_2.<SelectHostName>b__0 (System.Object v) [0x00000] in /Users/vidondai/Documents/xi-xcode11/xamarin-macios/external/Touch.Unit/NUnitLite/TouchRunner/TouchRunner.cs:204 
2019-08-14 15:21:04.592 dont link[7054:2130113] TCP connection failed when selecting 'hostname': System.Net.Sockets.SocketException (0x80004005): No route to host
  at System.Net.Sockets.TcpClient..ctor (System.String hostname, System.Int32 port) [0x0006d] in /Users/vidondai/Documents/xi-xcode11/xamarin-macios/external/mono/mcs/class/referencesource/System/net/System/Net/Sockets/TCPClient.cs:122 
  at MonoTouch.NUnit.UI.BaseTouchRunner+<>c__DisplayClass55_2.<SelectHostName>b__0 (System.Object v) [0x00000] in /Users/vidondai/Documents/xi-xcode11/xamarin-macios/external/Touch.Unit/NUnitLite/TouchRunner/TouchRunner.cs:204 
2019-08-14 15:21:04.592 dont link[7054:2130107] TCP connection failed when selecting 'hostname': System.Net.Sockets.SocketException (0x80004005): No route to host
  at System.Net.Sockets.TcpClient..ctor (System.String hostname, System.Int32 port) [0x0006d] in /Users/vidondai/Documents/xi-xcode11/xamarin-macios/external/mono/mcs/class/referencesource/System/net/System/Net/Sockets/TCPClient.cs:122 
  at MonoTouch.NUnit.UI.BaseTouchRunner+<>c__DisplayClass55_2.<SelectHostName>b__0 (System.Object v) [0x00000] in /Users/vidondai/Documents/xi-xcode11/xamarin-macios/external/Touch.Unit/NUnitLite/TouchRunner/TouchRunner.cs:204 
2019-08-14 15:21:04.593 dont link[7054:2130108] TCP connection failed when selecting 'hostname': System.Net.Sockets.SocketException (0x80004005): No route to host
  at System.Net.Sockets.TcpClient..ctor (System.String hostname, System.Int32 port) [0x0006d] in /Users/vidondai/Documents/xi-xcode11/xamarin-macios/external/mono/mcs/class/referencesource/System/net/System/Net/Sockets/TCPClient.cs:122 
  at MonoTouch.NUnit.UI.BaseTouchRunner+<>c__DisplayClass55_2.<SelectHostName>b__0 (System.Object v) [0x00000] in /Users/vidondai/Documents/xi-xcode11/xamarin-macios/external/Touch.Unit/NUnitLite/TouchRunner/TouchRunner.cs:204 
2019-08-14 15:21:04.593 dont link[7054:2130111] TCP connection failed when selecting 'hostname': System.Net.Sockets.SocketException (0x80004005): No route to host
  at System.Net.Sockets.TcpClient..ctor (System.String hostname, System.Int32 port) [0x0006d] in /Users/vidondai/Documents/xi-xcode11/xamarin-macios/external/mono/mcs/class/referencesource/System/net/System/Net/Sockets/TCPClient.cs:122 
  at MonoTouch.NUnit.UI.BaseTouchRunner+<>c__DisplayClass55_2.<SelectHostName>b__0 (System.Object v) [0x00000] in /Users/vidondai/Documents/xi-xcode11/xamarin-macios/external/Touch.Unit/NUnitLite/TouchRunner/TouchRunner.cs:204 
2019-08-14 15:21:04.593 dont link[7054:2130110] TCP connection failed when selecting 'hostname': System.Net.Sockets.SocketException (0x80004005): No route to host
  at System.Net.Sockets.TcpClient..ctor (System.String hostname, System.Int32 port) [0x0006d] in /Users/vidondai/Documents/xi-xcode11/xamarin-macios/external/mono/mcs/class/referencesource/System/net/System/Net/Sockets/TCPClient.cs:122 
  at MonoTouch.NUnit.UI.BaseTouchRunner+<>c__DisplayClass55_2.<SelectHostName>b__0 (System.Object v) [0x00000] in /Users/vidondai/Documents/xi-xcode11/xamarin-macios/external/Touch.Unit/NUnitLite/TouchRunner/TouchRunner.cs:204 
2019-08-14 15:21:04.594 dont link[7054:2130112] TCP connection failed when selecting 'hostname': System.Net.Sockets.SocketException (0x80004005): No route to host
  at System.Net.Sockets.TcpClient..ctor (System.String hostname, System.Int32 port) [0x0006d] in /Users/vidondai/Documents/xi-xcode11/xamarin-macios/external/mono/mcs/class/referencesource/System/net/System/Net/Sockets/TCPClient.cs:122 
  at MonoTouch.NUnit.UI.BaseTouchRunner+<>c__DisplayClass55_2.<SelectHostName>b__0 (System.Object v) [0x00000] in /Users/vidondai/Documents/xi-xcode11/xamarin-macios/external/Touch.Unit/NUnitLite/TouchRunner/TouchRunner.cs:204 
2019-08-14 15:21:04.594 dont link[7054:2130113] TCP connection failed when selecting 'hostname': System.Net.Sockets.SocketException (0x80004005): No route to host
  at System.Net.Sockets.TcpClient..ctor (System.String hostname, System.Int32 port) [0x0006d] in /Users/vidondai/Documents/xi-xcode11/xamarin-macios/external/mono/mcs/class/referencesource/System/net/System/Net/Sockets/TCPClient.cs:122 
  at MonoTouch.NUnit.UI.BaseTouchRunner+<>c__DisplayClass55_2.<SelectHostName>b__0 (System.Object v) [0x00000] in /Users/vidondai/Documents/xi-xcode11/xamarin-macios/external/Touch.Unit/NUnitLite/TouchRunner/TouchRunner.cs:204 
2019-08-14 15:22:21.673 dont link[7054:2130108] TCP connection failed when selecting 'hostname': System.Net.Sockets.SocketException (0x80004005): Connection timed out
  at System.Net.Sockets.TcpClient..ctor (System.String hostname, System.Int32 port) [0x0006d] in /Users/vidondai/Documents/xi-xcode11/xamarin-macios/external/mono/mcs/class/referencesource/System/net/System/Net/Sockets/TCPClient.cs:122 
  at MonoTouch.NUnit.UI.BaseTouchRunner+<>c__DisplayClass55_2.<SelectHostName>b__0 (System.Object v) [0x00000] in /Users/vidondai/Documents/xi-xcode11/xamarin-macios/external/Touch.Unit/NUnitLite/TouchRunner/TouchRunner.cs:204 
2019-08-14 15:22:21.675 dont link[7054:2130107] TCP connection failed when selecting 'hostname': System.Net.Sockets.SocketException (0x80004005): Connection timed out
  at System.Net.Sockets.TcpClient..ctor (System.String hostname, System.Int32 port) [0x0006d] in /Users/vidondai/Documents/xi-xcode11/xamarin-macios/external/mono/mcs/class/referencesource/System/net/System/Net/Sockets/TCPClient.cs:122 
  at MonoTouch.NUnit.UI.BaseTouchRunner+<>c__DisplayClass55_2.<SelectHostName>b__0 (System.Object v) [0x00000] in /Users/vidondai/Documents/xi-xcode11/xamarin-macios/external/Touch.Unit/NUnitLite/TouchRunner/TouchRunner.cs:204 
2019-08-14 15:22:21.677 dont link[7054:2130067] Couldn't establish a TCP connection with any of the hostnames: 10.160.159.16,10.92.168.38,fe80::1008:1dd8:9b64:e234,2001:4898:4030:14:1860:80bb:15bd:38cb,2001:4898:4030:14:2c39:9ce2:34b4:f349,fe80::aede:48ff:fe00:1122,fe80::8a7:4a1a:21d8:76e4,2001:4898:4070:101b:2d:a7ad:28dc:1c49,2001:4898:4070:101b:d0f5:653b:2a8c:95cc,fe80::fc1d:e4ff:fe84:a0f1
```

It's especially useful to debug issues, notably: https://github.com/xamarin/maccore/issues/1741