### PR TITLE
[TouchRunner] Fix colors for iOS 13 dark mode

### DIFF
--- a/NUnitLite/TouchRunner/TestCaseElement.cs
+++ b/NUnitLite/TouchRunner/TestCaseElement.cs
@@ -84,7 +84,7 @@ namespace MonoTouch.NUnit.UI {
 		{
 			if (Result.IsIgnored ()) {
 				Value = Result.GetMessage ();
-				DetailColor = UIColor.SystemOrangeColor;
+				DetailColor = Orange;
 			} else if (Result.IsSuccess () || Result.IsInconclusive ()) {
 				int counter = Result.AssertCount;
 				Value = String.Format ("{0} {1} ms for {2} assertion{3}",
@@ -94,7 +94,7 @@ namespace MonoTouch.NUnit.UI {
 				DetailColor = DarkGreen;
 			} else if (Result.IsFailure ()) {
 				Value = Result.GetMessage ();
-				DetailColor = UIColor.SystemRedColor;
+				DetailColor = Red;
 			} else {
 				// Assert.Ignore falls into this
 				Value = Result.GetMessage ();

--- a/NUnitLite/TouchRunner/TestCaseElement.cs
+++ b/NUnitLite/TouchRunner/TestCaseElement.cs
@@ -84,7 +84,7 @@ namespace MonoTouch.NUnit.UI {
 		{
 			if (Result.IsIgnored ()) {
 				Value = Result.GetMessage ();
-				DetailColor = UIColor.Orange;
+				DetailColor = UIColor.SystemOrangeColor;
 			} else if (Result.IsSuccess () || Result.IsInconclusive ()) {
 				int counter = Result.AssertCount;
 				Value = String.Format ("{0} {1} ms for {2} assertion{3}",
@@ -94,7 +94,7 @@ namespace MonoTouch.NUnit.UI {
 				DetailColor = DarkGreen;
 			} else if (Result.IsFailure ()) {
 				Value = Result.GetMessage ();
-				DetailColor = UIColor.Red;
+				DetailColor = UIColor.SystemRedColor;
 			} else {
 				// Assert.Ignore falls into this
 				Value = Result.GetMessage ();

--- a/NUnitLite/TouchRunner/TestElement.cs
+++ b/NUnitLite/TouchRunner/TestElement.cs
@@ -35,7 +35,7 @@ namespace MonoTouch.NUnit.UI {
 
 	abstract class TestElement : StyledMultilineElement {
 		
-		static internal UIColor DarkGreen = UIColor.FromRGB (0x00, 0x77, 0x00);
+		static internal UIColor DarkGreen = UIColor.SystemGreenColor;
 	
 		private TestResult result;
 		
@@ -46,7 +46,8 @@ namespace MonoTouch.NUnit.UI {
 				throw new ArgumentNullException ("test");
 			if (runner == null)
 				throw new ArgumentNullException ("runner");
-		
+
+			TextColor = UIColor.LabelColor;
 			Test = test;
 			Runner = runner;
 		}

--- a/NUnitLite/TouchRunner/TestElement.cs
+++ b/NUnitLite/TouchRunner/TestElement.cs
@@ -35,7 +35,9 @@ namespace MonoTouch.NUnit.UI {
 
 	abstract class TestElement : StyledMultilineElement {
 		
-		static internal UIColor DarkGreen = UIColor.SystemGreenColor;
+		static internal UIColor DarkGreen = UIDevice.CurrentDevice.CheckSystemVersion (13, 0) ? UIColor.SystemGreenColor : UIColor.FromRGB (0x00, 0x77, 0x00);
+		static internal UIColor Orange = UIDevice.CurrentDevice.CheckSystemVersion (13, 0) ? UIColor.SystemOrangeColor : UIColor.Orange;
+		static internal UIColor Red = UIDevice.CurrentDevice.CheckSystemVersion (13, 0) ? UIColor.SystemRedColor : UIColor.Red;
 	
 		private TestResult result;
 		
@@ -47,7 +49,9 @@ namespace MonoTouch.NUnit.UI {
 			if (runner == null)
 				throw new ArgumentNullException ("runner");
 
-			TextColor = UIColor.LabelColor;
+			if (UIDevice.CurrentDevice.CheckSystemVersion (13, 0)) {
+				TextColor = UIColor.LabelColor;
+			}
 			Test = test;
 			Runner = runner;
 		}

--- a/NUnitLite/TouchRunner/TestSuiteElement.cs
+++ b/NUnitLite/TouchRunner/TestSuiteElement.cs
@@ -48,7 +48,7 @@ namespace MonoTouch.NUnit.UI {
 					runner.Show (Suite);
 				};
 			} else {
-				DetailColor = UIColor.Orange;
+				DetailColor = UIColor.SystemOrangeColor;
 				Value = "No test was found inside this suite";
 			}
 		}
@@ -75,7 +75,7 @@ namespace MonoTouch.NUnit.UI {
 				if (positive > 1)
 					sb.Append ('s');
 			} else {
-				DetailColor = UIColor.Red;
+				DetailColor = UIColor.SystemRedColor;
 				if (positive > 0)
 					sb.Append (positive).Append (" success");
 				if (sb.Length > 0)

--- a/NUnitLite/TouchRunner/TestSuiteElement.cs
+++ b/NUnitLite/TouchRunner/TestSuiteElement.cs
@@ -48,7 +48,7 @@ namespace MonoTouch.NUnit.UI {
 					runner.Show (Suite);
 				};
 			} else {
-				DetailColor = UIColor.SystemOrangeColor;
+				DetailColor = Orange;
 				Value = "No test was found inside this suite";
 			}
 		}

--- a/NUnitLite/TouchRunner/TestSuiteElement.cs
+++ b/NUnitLite/TouchRunner/TestSuiteElement.cs
@@ -75,7 +75,7 @@ namespace MonoTouch.NUnit.UI {
 				if (positive > 1)
 					sb.Append ('s');
 			} else {
-				DetailColor = UIColor.SystemRedColor;
+				DetailColor = Red;
 				if (positive > 0)
 					sb.Append (positive).Append (" success");
 				if (sb.Length > 0)


### PR DESCRIPTION
Now we fully support light and dark modes. Before that we'd show the tests in black https://github.com/migueldeicaza/MonoTouch.Dialog/blob/98c2a56eaf37a483b47f12599675e41b91319d38/MonoTouch.Dialog/Elements.cs#L879 and that didn't play nice with dark mode (: