### PR TITLE
Included option to skip log file header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.vs/
 .DS_Store
 *.pidb
 *.userprefs

--- a/Touch.Server/Main.cs
+++ b/Touch.Server/Main.cs
@@ -107,14 +107,13 @@ class SimpleListener {
 		connected.Set ();
 
 		using (FileStream fs = File.OpenWrite (logfile)) {
-			if (!skipHeader)
-			{
+			if (!skipHeader) {
                 // a few extra bits of data only available from this side
                 string header = String.Format("[Local Date/Time:\t{1}]{0}[Remote Address:\t{2}]{0}",
                     Environment.NewLine, DateTime.Now, remote);
                 byte[] array = Encoding.UTF8.GetBytes(header);
-                fs.Write(array, 0, array.Length);
-                fs.Flush();
+                fs.Write (array, 0, array.Length);
+                fs.Flush ();
             }
 			// now simply copy what we receive
 			int i;

--- a/Touch.Server/Main.cs
+++ b/Touch.Server/Main.cs
@@ -108,13 +108,13 @@ class SimpleListener {
 
 		using (FileStream fs = File.OpenWrite (logfile)) {
 			if (!skipHeader) {
-                // a few extra bits of data only available from this side
-                string header = String.Format("[Local Date/Time:\t{1}]{0}[Remote Address:\t{2}]{0}",
-                    Environment.NewLine, DateTime.Now, remote);
-                byte[] array = Encoding.UTF8.GetBytes(header);
-                fs.Write (array, 0, array.Length);
-                fs.Flush ();
-            }
+				// a few extra bits of data only available from this side
+				string header = String.Format("[Local Date/Time:\t{1}]{0}[Remote Address:\t{2}]{0}",
+					Environment.NewLine, DateTime.Now, remote);
+				byte[] array = Encoding.UTF8.GetBytes(header);
+				fs.Write (array, 0, array.Length);
+				fs.Flush ();
+			}
 			// now simply copy what we receive
 			int i;
 			int total = 0;


### PR DESCRIPTION
The current code includes a header with the log file and prevents the output from being processed in an automated build process.  By default, the header will continue to be included in the log file.

> -skipheader [Exclude the header from the log file (default: false)]

