### PR TITLE
[TCP] Add support to use a tcp tunnel.

### DIFF
--- a/NUnitLite/TouchRunner/TcpTextWriter.cs
+++ b/NUnitLite/TouchRunner/TcpTextWriter.cs
@@ -21,7 +21,7 @@ namespace MonoTouch.NUnit {
 		TcpListener server;
 		private StreamWriter writer;
 
-		public TcpTextWriter (string hostName, int port, bool isTunnel = true)
+		public TcpTextWriter (string hostName, int port, bool isTunnel = false)
 		{
 			if (hostName == null)
 				throw new ArgumentNullException ("hostName");

--- a/NUnitLite/TouchRunner/TcpTextWriter.cs
+++ b/NUnitLite/TouchRunner/TcpTextWriter.cs
@@ -39,6 +39,7 @@ namespace MonoTouch.NUnit {
 			try {
 				if (isTunnel) {
 					server = new TcpListener (IPAddress.Any, Port);
+					server.Server.ReceiveTimeout = 5000; // timeout after 5s
 					server.Start ();
 					client = server.AcceptTcpClient ();
 					// block until we have the ping from the client side

--- a/NUnitLite/TouchRunner/TcpTextWriter.cs
+++ b/NUnitLite/TouchRunner/TcpTextWriter.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using System.Net;
 using System.Net.Sockets;
 using System.Text;
 
@@ -17,16 +18,18 @@ namespace MonoTouch.NUnit {
 	public class TcpTextWriter : TextWriter {
 		
 		private TcpClient client;
+		TcpListener server;
 		private StreamWriter writer;
 
-		public TcpTextWriter (string hostName, int port)
+		public TcpTextWriter (string hostName, int port, bool isTunnel = true)
 		{
 			if (hostName == null)
 				throw new ArgumentNullException ("hostName");
 			if ((port < 0) || (port > UInt16.MaxValue))
 				throw new ArgumentException ("port");
-			
-			HostName = hostName;
+			if (!isTunnel)
+				HostName = hostName;
+
 			Port = port;
 
 #if __IOS__
@@ -34,7 +37,22 @@ namespace MonoTouch.NUnit {
 #endif
 
 			try {
-				client = new TcpClient (hostName, port);
+				if (isTunnel) {
+					server = new TcpListener (IPAddress.Any, Port);
+					server.Start ();
+					client = server.AcceptTcpClient ();
+					// block until we have the ping from the client side
+					int i;
+					byte [] buffer = new byte [16 * 1024];
+					var stream = client.GetStream ();
+					while ((i = stream.Read (buffer, 0, buffer.Length)) != 0) {
+						var message = Encoding.UTF8.GetString (buffer);
+						if (message.Contains ("ping"))
+							break;
+					}
+				} else {
+					client = new TcpClient (HostName, port);
+				}
 				writer = new StreamWriter (client.GetStream ());
 			}
 			catch {

--- a/NUnitLite/TouchRunner/TouchOptions.cs
+++ b/NUnitLite/TouchRunner/TouchOptions.cs
@@ -98,7 +98,7 @@ namespace MonoTouch.NUnit.UI {
 				{ "autostart", "If the app should automatically start running the tests.", v => AutoStart = true },
 				{ "hostname=", "Comma-separated list of host names or IP address to (try to) connect to", v => HostName = v },
 				{ "hostport=", "HTTP/TCP port to connect to.", v => HostPort = int.Parse (v) },
-				{ "use_tcp_tunnel", "Use a tcp tunnel to connect to the host.", v => UseTcpTunnel = true },
+				{ "use-tcp-tunnel", "Use a TCP tunnel to connect to the host.", v => UseTcpTunnel = true },
 				{ "enablenetwork", "Enable the network reporter.", v => EnableNetwork = true },
 				{ "transport=", "Select transport method. Either TCP (default), HTTP or FILE.", v => Transport = v },
 				{ "enablexml", "Enable the xml reported.", v => EnableXml = false },
@@ -151,12 +151,13 @@ namespace MonoTouch.NUnit.UI {
 #else
 			var network = new BooleanElement ("Enable", EnableNetwork);
 #endif
-
 			var host = new EntryElement ("Host Name", "name", HostName);
 			host.KeyboardType = UIKeyboardType.ASCIICapable;
 			
 			var port = new EntryElement ("Port", "name", HostPort.ToString ());
 			port.KeyboardType = UIKeyboardType.NumberPad;
+
+			var useTunnel = new BooleanElement ("Use TCP Tunnel", UseTcpTunnel);
 			
 #if TVOS
 			var sort = new StringElement (string.Format ("Sort Names: ", SortNames));
@@ -165,7 +166,7 @@ namespace MonoTouch.NUnit.UI {
 #endif
 
 			var root = new RootElement ("Options") {
-				new Section ("Remote Server") { network, host, port },
+				new Section ("Remote Server") { network, host, port, useTunnel },
 				new Section ("Display") { sort }
 			};
 				
@@ -180,6 +181,7 @@ namespace MonoTouch.NUnit.UI {
 					HostPort = p;
 				else
 					HostPort = -1;
+				UseTcpTunnel = useTunnel.Value;
 #if !TVOS
 				SortNames = sort.Value;
 #endif
@@ -189,6 +191,7 @@ namespace MonoTouch.NUnit.UI {
 				defaults.SetString (HostName ?? String.Empty, "network.host.name");
 				defaults.SetInt (HostPort, "network.host.port");
 				defaults.SetBool (SortNames, "display.sort");
+				defaults.SetBool (UseTcpTunnel, "execution.usetcptunnel");
 			};
 			
 			return dv;

--- a/NUnitLite/TouchRunner/TouchOptions.cs
+++ b/NUnitLite/TouchRunner/TouchOptions.cs
@@ -59,6 +59,7 @@ namespace MonoTouch.NUnit.UI {
 			EnableXml = defaults.BoolForKey ("xml.enabled");
 			HostName = defaults.StringForKey ("network.host.name");
 			HostPort = (int)defaults.IntForKey ("network.host.port");
+			UseTcpTunnel = defaults.BoolForKey ("execution.usetcptunnel");
 			Transport = defaults.StringForKey ("network.transport");
 			SortNames = defaults.BoolForKey ("display.sort");
 			LogFile = defaults.StringForKey ("log.file");
@@ -72,6 +73,8 @@ namespace MonoTouch.NUnit.UI {
 				EnableNetwork = b;
 			if (!string.IsNullOrEmpty (Environment.GetEnvironmentVariable ("NUNIT_HOSTNAME")))
 				HostName = Environment.GetEnvironmentVariable ("NUNIT_HOSTNAME");
+			if (bool.TryParse (Environment.GetEnvironmentVariable ("USE_TCP_TUNNEL"), out b))
+				UseTcpTunnel = b;
 			int i;
 			if (int.TryParse (Environment.GetEnvironmentVariable ("NUNIT_HOSTPORT"), out i))
 				HostPort = i;
@@ -95,6 +98,7 @@ namespace MonoTouch.NUnit.UI {
 				{ "autostart", "If the app should automatically start running the tests.", v => AutoStart = true },
 				{ "hostname=", "Comma-separated list of host names or IP address to (try to) connect to", v => HostName = v },
 				{ "hostport=", "HTTP/TCP port to connect to.", v => HostPort = int.Parse (v) },
+				{ "use_tcp_tunnel", "Use a tcp tunnel to connect to the host.", v => UseTcpTunnel = true },
 				{ "enablenetwork", "Enable the network reporter.", v => EnableNetwork = true },
 				{ "transport=", "Select transport method. Either TCP (default), HTTP or FILE.", v => Transport = v },
 				{ "enablexml", "Enable the xml reported.", v => EnableXml = false },
@@ -121,6 +125,8 @@ namespace MonoTouch.NUnit.UI {
 		public string HostName { get; private set; }
 		
 		public int HostPort { get; private set; }
+
+		public bool UseTcpTunnel { get; set; } = true;
 		
 		public bool AutoStart { get; set; }
 		

--- a/NUnitLite/TouchRunner/TouchRunner.cs
+++ b/NUnitLite/TouchRunner/TouchRunner.cs
@@ -266,13 +266,19 @@ namespace MonoTouch.NUnit.UI {
 							Console.WriteLine ("Unknown transport '{0}': switching to default (TCP)", options.Transport);
 							goto case "TCP";
 						case "TCP":
-							hostname = SelectHostName (options.HostName.Split (','), options.HostPort);
+							if (!options.UseTcpTunnel)
+								hostname = SelectHostName (options.HostName.Split (','), options.HostPort);
+							else
+								hostname = "localhost";
 							if (string.IsNullOrEmpty (hostname)) {
 								Console.WriteLine ("Couldn't establish a TCP connection with any of the hostnames: {0}", options.HostName);
 								break;
 							}
-							Console.WriteLine ("[{0}] Sending '{1}' results to {2}:{3}", now, message, hostname, options.HostPort);
-							defaultWriter = new TcpTextWriter (hostname, options.HostPort);
+							if (!options.UseTcpTunnel)
+								Console.WriteLine ("[{0}] Sending '{1}' results to {2}:{3}", now, message, hostname, options.HostPort);
+							else
+								Console.WriteLine ("[{0}] Sending '{1}' results to {2} over a tcp tunnel", now, message, options.HostPort);
+							defaultWriter = new TcpTextWriter (hostname, options.HostPort, options.UseTcpTunnel);
 							break;
 						}
 						if (options.EnableXml) {


### PR DESCRIPTION
Using a tcp tunnel inverts the way we communicate with the device. We
move from a TcpClient to a TcpListener. In this case we need to wait
until we have a client connected that sends us a ping to start running
the tests.

This commit does not mean that we won't be able to use a normal tcp
conection, just means that if required, we can use a tunnel