### PR TITLE
Remove CLSCompliant attribute which causes compiler warnings.

### DIFF
--- a/NUnitLite/TouchRunner/TouchOptions.cs
+++ b/NUnitLite/TouchRunner/TouchOptions.cs
@@ -143,7 +143,6 @@ namespace MonoTouch.NUnit.UI {
 		public bool SortNames { get; set; }
 		
 #if !__WATCHOS__
-		[CLSCompliant (false)]
 		public UIViewController GetViewController ()
 		{
 #if TVOS

--- a/NUnitLite/TouchRunner/TouchRunner.cs
+++ b/NUnitLite/TouchRunner/TouchRunner.cs
@@ -505,7 +505,6 @@ namespace MonoTouch.NUnit.UI {
 		
 		UIWindow window;
 
-		[CLSCompliant (false)]
 		public TouchRunner (UIWindow window)
 		{
 			if (window == null)
@@ -514,7 +513,6 @@ namespace MonoTouch.NUnit.UI {
 			this.window = window;
 		}
 				
-		[CLSCompliant (false)]
 		public UINavigationController NavigationController {
 			get { return (UINavigationController) window.RootViewController; }
 		}
@@ -525,7 +523,6 @@ namespace MonoTouch.NUnit.UI {
 			UIApplication.SharedApplication.PerformSelector (selector, UIApplication.SharedApplication, 0);						
 		}
 
-		[CLSCompliant (false)]
 		public UIViewController GetViewController ()
 		{
 			var menu = new RootElement ("Test Runner");

--- a/NUnitLite/TouchRunner/TouchViewController.cs
+++ b/NUnitLite/TouchRunner/TouchViewController.cs
@@ -40,7 +40,6 @@ using CGSize = global::System.Drawing.SizeF;
 
 namespace MonoTouch.NUnit.UI {
 
-	[CLSCompliant (false)]
 	public partial class TouchViewController : DialogViewController {
 
 		public TouchViewController (RootElement root) : base (root, true)


### PR DESCRIPTION
Fixes several compiler warnings:

    TouchRunner/TouchRunner.cs(508,32): warning CS3001: Argument type 'UIWindow' is not CLS-compliant
    TouchRunner/TouchRunner.cs(516,33): warning CS3003: Type of 'TouchRunner.NavigationController' is not CLS-compliant
    TouchRunner/TouchRunner.cs(526,27): warning CS3002: Return type of 'TouchRunner.GetViewController()' is not CLS-compliant
    TouchRunner/TouchOptions.cs(146,27): warning CS3002: Return type of 'TouchOptions.GetViewController()' is not CLS-compliant
    TouchRunner/TouchViewController.cs(43,23): warning CS3009: 'TouchViewController': base type 'DialogViewController' is not CLS-compliant
    TouchRunner/TouchViewController.cs(45,43): warning CS3001: Argument type 'RootElement' is not CLS-compliant