### PR TITLE
[TouchRunner] Update the current element even if showing a sub element with failure info.

### DIFF
--- a/NUnitLite/TouchRunner/TestCaseElement.cs
+++ b/NUnitLite/TouchRunner/TestCaseElement.cs
@@ -60,7 +60,9 @@ namespace MonoTouch.NUnit.UI {
 					};
 					var dvc = new DialogViewController (root, true) { Autorotate = true };
 					runner.NavigationController.PushViewController (dvc, true);
-				} else if (GetContainerTableView () != null) {
+				}
+				// we still need to update our current element
+				if (GetContainerTableView () != null) {
 					var root = GetImmediateRootElement ();
 					root.Reload (this, UITableViewRowAnimation.Fade);
 				}


### PR DESCRIPTION
Otherwise the current element will show up as not executed when returning from the sub element.