### PR TITLE
[TouchRunner] Only update the UI for a single test after the test has finished running.

### DIFF
--- a/NUnitLite/TouchRunner/TestCaseElement.cs
+++ b/NUnitLite/TouchRunner/TestCaseElement.cs
@@ -36,6 +36,7 @@ using NUnit.Framework.Api;
 namespace MonoTouch.NUnit.UI {
 	
 	class TestCaseElement : TestElement {
+		bool tapped;
 		
 		public TestCaseElement (TestMethod testCase, TouchRunner runner)
 			: base (testCase, runner)
@@ -59,21 +60,7 @@ namespace MonoTouch.NUnit.UI {
 #endif
 
 				Runner.CloseWriter ();
-				// display more details on (any) failure (but not when ignored)
-				if ((TestCase.RunState == RunState.Runnable) && !Result.IsSuccess ()) {
-					var root = new RootElement ("Results") {
-						new Section () {
-							new TestResultElement (Result)
-						}
-					};
-					var dvc = new DialogViewController (root, true) { Autorotate = true };
-					runner.NavigationController.PushViewController (dvc, true);
-				}
-				// we still need to update our current element
-				if (GetContainerTableView () != null) {
-					var root = GetImmediateRootElement ();
-					root.Reload (this, UITableViewRowAnimation.Fade);
-				}
+				tapped = true;
 			};
 		}
 		
@@ -83,7 +70,7 @@ namespace MonoTouch.NUnit.UI {
 		
 		public void Run ()
 		{
-			Update (Runner.Run (TestCase));
+			Runner.Run (TestCase);
 		}
 		
 		public override void Update ()
@@ -104,6 +91,25 @@ namespace MonoTouch.NUnit.UI {
 			} else {
 				// Assert.Ignore falls into this
 				Value = Result.GetMessage ();
+			}
+
+			if (tapped) {
+				// display more details on (any) failure (but not when ignored)
+				if ((TestCase.RunState == RunState.Runnable) && !Result.IsSuccess ()) {
+					var root = new RootElement ("Results") {
+						new Section () {
+							new TestResultElement (Result)
+						}
+					};
+					var dvc = new DialogViewController (root, true) { Autorotate = true };
+					Runner.NavigationController.PushViewController (dvc, true);
+				}
+				// we still need to update our current element
+				if (GetContainerTableView () != null) {
+					var root = GetImmediateRootElement ();
+					root.Reload (this, UITableViewRowAnimation.Fade);
+				}
+				tapped = false;
 			}
 		}
 	}

--- a/NUnitLite/TouchRunner/TestSuiteElement.cs
+++ b/NUnitLite/TouchRunner/TestSuiteElement.cs
@@ -55,7 +55,7 @@ namespace MonoTouch.NUnit.UI {
 		
 		public void Run ()
 		{
-			Result = Runner.Run (Suite);
+			Runner.Run (Suite);
 		}
 		
 		public override void Update ()

--- a/NUnitLite/TouchRunner/TouchRunner.cs
+++ b/NUnitLite/TouchRunner/TouchRunner.cs
@@ -507,7 +507,7 @@ namespace MonoTouch.NUnit.UI {
 			return true;
 		}
 
-		public TestResult Run (Test test)
+		public void Run (Test test)
 		{
 			PassedCount = 0;
 			IgnoredCount = 0;
@@ -543,7 +543,6 @@ namespace MonoTouch.NUnit.UI {
 			wi.Execute (current);
 			Result = wi.Result;
 #endif
-			return Result;
 		}
 
 		public ITest LoadedTest {


### PR DESCRIPTION
Only update the UI for a single test after we're notified that the test has
finished running. This is a step towards making async tests work properly,
where we can't assume that the test has finished after calling Run.

Also we only want to show more details for a test if we ran that test as a
result of tapping on it.