### PR TITLE
[TouchRunner] Print test output to the console.

### DIFF
--- a/NUnitLite/TouchRunner/TouchRunner.cs
+++ b/NUnitLite/TouchRunner/TouchRunner.cs
@@ -439,6 +439,10 @@ namespace MonoTouch.NUnit.UI {
 					Writer.Write (" : {0}", message.Replace ("\r\n", "\\r\\n"));
 				}
 				Writer.WriteLine ();
+#if NUNITLITE_NUGET
+				if (!string.IsNullOrEmpty (result.Output))
+					Writer.WriteLine (result.Output);
+#endif
 
 				string stacktrace = result.StackTrace;
 				if (!String.IsNullOrEmpty (result.StackTrace)) {


### PR DESCRIPTION
Updated versions of NUnit will capture Console.Out during a test run. We want
to show it in the Console, so write it there when the test has finished.

I couldn't find a way to tell NUnit to not capture Console.Out in the first place.