### PR TITLE
[TouchRunner] Fix network logging to log if we're logging to a file even if EnableNetwork is false.

### DIFF
--- a/NUnitLite/TouchRunner/TouchOptions.cs
+++ b/NUnitLite/TouchRunner/TouchOptions.cs
@@ -132,7 +132,7 @@ namespace MonoTouch.NUnit.UI {
 		public string LogFile { get; set; }
 
 		public bool ShowUseNetworkLogger {
-			get { return (EnableNetwork && !String.IsNullOrWhiteSpace (HostName) && (HostPort > 0 || Transport == "FILE")); }
+			get { return (EnableNetwork && !String.IsNullOrWhiteSpace (HostName) && (HostPort > 0)) || Transport == "FILE"; }
 		}
 
 		public bool SortNames { get; set; }


### PR DESCRIPTION
The property should probably be renamed, but that's for another time.