### PR TITLE
[Touch.Client] Add API to exclude tests based on categories.

### DIFF
--- a/NUnitLite/TouchRunner/ExcludedCategoryFilter.cs
+++ b/NUnitLite/TouchRunner/ExcludedCategoryFilter.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+
+using NUnit.Framework.Internal;
+using NUnit.Framework.Interfaces;
+
+namespace MonoTouch.NUnit.UI {
+	class ExcludeCategoryFilter : TestFilter {
+		public HashSet<string> ExcludedCategories { get; private set; }
+
+		public ExcludeCategoryFilter (IEnumerable<string> categories)
+		{
+			ExcludedCategories = new HashSet<string> (categories);
+		}
+
+		public override TNode AddToXml (TNode parentNode, bool recursive)
+		{
+			throw new NotImplementedException ();
+		}
+
+		public override bool Match (ITest test)
+		{
+			var categories = test.Properties ["Category"];
+			if (categories != null) {
+				foreach (string cat in categories) {
+					if (ExcludedCategories.Contains (cat))
+						return false;
+				}
+			}
+			
+			if (test.Parent != null)
+				return Match (test.Parent);
+
+			return true;
+		}
+
+		public override bool Pass (ITest test)
+		{
+			return Match (test);
+		}
+	}
+}

--- a/Touch.Client/dotnet/iOS/Touch.Client-iOS.dotnet.csproj
+++ b/Touch.Client/dotnet/iOS/Touch.Client-iOS.dotnet.csproj
@@ -9,10 +9,10 @@
     <AssemblyName>Touch.Client</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="..\..\NUnitLite\TouchRunner\ExcludedCategoryFilter.cs">
+    <Compile Include="..\..\..\NUnitLite\TouchRunner\ExcludedCategoryFilter.cs">
       <Link>ExcludedCategoryFilter.cs</Link>
     </Compile>
-    <Compile Include="..\..\NUnitLite\TouchRunner\HttpTextWriter.cs">
+    <Compile Include="..\NUnitLite\TouchRunner\HttpTextWriter.cs">
       <Link>HttpTextWriter.cs</Link>
     </Compile>
     <Compile Include="..\NUnitLite\TouchRunner\NUnitOutputTextWriter.cs">

--- a/Touch.Client/dotnet/iOS/Touch.Client-iOS.dotnet.csproj
+++ b/Touch.Client/dotnet/iOS/Touch.Client-iOS.dotnet.csproj
@@ -9,7 +9,10 @@
     <AssemblyName>Touch.Client</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="..\NUnitLite\TouchRunner\HttpTextWriter.cs">
+    <Compile Include="..\..\NUnitLite\TouchRunner\ExcludedCategoryFilter.cs">
+      <Link>ExcludedCategoryFilter.cs</Link>
+    </Compile>
+    <Compile Include="..\..\NUnitLite\TouchRunner\HttpTextWriter.cs">
       <Link>HttpTextWriter.cs</Link>
     </Compile>
     <Compile Include="..\NUnitLite\TouchRunner\NUnitOutputTextWriter.cs">

--- a/Touch.Client/dotnet/tvOS/Touch.Client-tvOS.dotnet.csproj
+++ b/Touch.Client/dotnet/tvOS/Touch.Client-tvOS.dotnet.csproj
@@ -9,10 +9,10 @@
     <AssemblyName>Touch.Client</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="..\..\NUnitLite\TouchRunner\ExcludedCategoryFilter.cs">
+    <Compile Include="..\..\..\NUnitLite\TouchRunner\ExcludedCategoryFilter.cs">
       <Link>ExcludedCategoryFilter.cs</Link>
     </Compile>
-    <Compile Include="..\..\NUnitLite\TouchRunner\HttpTextWriter.cs">
+    <Compile Include="..\NUnitLite\TouchRunner\HttpTextWriter.cs">
       <Link>HttpTextWriter.cs</Link>
     </Compile>
     <Compile Include="..\NUnitLite\TouchRunner\NUnitOutputTextWriter.cs">

--- a/Touch.Client/dotnet/tvOS/Touch.Client-tvOS.dotnet.csproj
+++ b/Touch.Client/dotnet/tvOS/Touch.Client-tvOS.dotnet.csproj
@@ -9,7 +9,10 @@
     <AssemblyName>Touch.Client</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="..\NUnitLite\TouchRunner\HttpTextWriter.cs">
+    <Compile Include="..\..\NUnitLite\TouchRunner\ExcludedCategoryFilter.cs">
+      <Link>ExcludedCategoryFilter.cs</Link>
+    </Compile>
+    <Compile Include="..\..\NUnitLite\TouchRunner\HttpTextWriter.cs">
       <Link>HttpTextWriter.cs</Link>
     </Compile>
     <Compile Include="..\NUnitLite\TouchRunner\NUnitOutputTextWriter.cs">

--- a/Touch.Client/iOS/Touch.Client-iOS.csproj
+++ b/Touch.Client/iOS/Touch.Client-iOS.csproj
@@ -41,6 +41,9 @@
     <Folder Include="Resources\" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\..\NUnitLite\TouchRunner\ExcludedCategoryFilter.cs">
+      <Link>ExcludedCategoryFilter.cs</Link>
+    </Compile>
     <Compile Include="..\..\NUnitLite\TouchRunner\HttpTextWriter.cs">
       <Link>HttpTextWriter.cs</Link>
     </Compile>

--- a/Touch.Client/macOS/full/Touch.Client-macOS-full.csproj
+++ b/Touch.Client/macOS/full/Touch.Client-macOS-full.csproj
@@ -41,6 +41,9 @@
     <Folder Include="Resources\" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\..\..\NUnitLite\TouchRunner\ExcludedCategoryFilter.cs">
+      <Link>ExcludedCategoryFilter.cs</Link>
+    </Compile>
     <Compile Include="..\..\..\NUnitLite\TouchRunner\HttpTextWriter.cs">
       <Link>HttpTextWriter.cs</Link>
     </Compile>

--- a/Touch.Client/macOS/mobile/Touch.Client-macOS-mobile.csproj
+++ b/Touch.Client/macOS/mobile/Touch.Client-macOS-mobile.csproj
@@ -41,6 +41,9 @@
     <Folder Include="Resources\" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\..\..\NUnitLite\TouchRunner\ExcludedCategoryFilter.cs">
+      <Link>ExcludedCategoryFilter.cs</Link>
+    </Compile>
     <Compile Include="..\..\..\NUnitLite\TouchRunner\HttpTextWriter.cs">
       <Link>HttpTextWriter.cs</Link>
     </Compile>

--- a/Touch.Client/tvOS/Touch.Client-tvOS.csproj
+++ b/Touch.Client/tvOS/Touch.Client-tvOS.csproj
@@ -41,6 +41,9 @@
     <Folder Include="Resources\" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\..\NUnitLite\TouchRunner\ExcludedCategoryFilter.cs">
+      <Link>ExcludedCategoryFilter.cs</Link>
+    </Compile>
     <Compile Include="..\..\NUnitLite\TouchRunner\HttpTextWriter.cs">
       <Link>HttpTextWriter.cs</Link>
     </Compile>

--- a/Touch.Client/watchOS/Touch.Client-watchOS.csproj
+++ b/Touch.Client/watchOS/Touch.Client-watchOS.csproj
@@ -41,6 +41,9 @@
     <Folder Include="Resources\" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\..\NUnitLite\TouchRunner\ExcludedCategoryFilter.cs">
+      <Link>ExcludedCategoryFilter.cs</Link>
+    </Compile>
     <Compile Include="..\..\NUnitLite\TouchRunner\HttpTextWriter.cs">
       <Link>HttpTextWriter.cs</Link>
     </Compile>


### PR DESCRIPTION
The NUnitLite API to create test filters is very rudimentary (either subclass
TestFilter, or have NUnitLite create the filter based on an xml string), so we
can at least make it easy for consumers to exclude tests based on categories,
which we need to be able to do for our tests anyway.