### PR TITLE
[Touch.Client] Use the right TargetFrameworks.

### DIFF
--- a/Touch.Client/dotnet/iOS/Touch.Client-iOS.dotnet.csproj
+++ b/Touch.Client/dotnet/iOS/Touch.Client-iOS.dotnet.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.iOS.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net5.0-ios</TargetFramework>
     <DefineConstants>NUNITLITE_NUGET</DefineConstants>
     <LangVersion>latest</LangVersion>
     <!-- Currently, NuGet is not able to restore existing Xamarin.iOS packages for a .NET 5 project, so use AssetTargetFallback to tell NuGet that the existing packages work -->

--- a/Touch.Client/dotnet/tvOS/Touch.Client-tvOS.dotnet.csproj
+++ b/Touch.Client/dotnet/tvOS/Touch.Client-tvOS.dotnet.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.tvOS.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net5.0-tvos</TargetFramework>
     <DefineConstants>NUNITLITE_NUGET</DefineConstants>
     <LangVersion>latest</LangVersion>
     <!-- Currently, NuGet is not able to restore existing Xamarin.TVOS packages for a .NET 5 project, so use AssetTargetFallback to tell NuGet that the existing packages work -->


### PR DESCRIPTION
.NET 5 has added support for our TargetFrameworks, so let's start using them.