### PR TITLE
[Touch.Client] Use 'Microsoft.NET.Sdk' instead of 'Microsoft.<platform>.Sdk'.

### DIFF
--- a/Touch.Client/dotnet/iOS/Touch.Client-iOS.dotnet.csproj
+++ b/Touch.Client/dotnet/iOS/Touch.Client-iOS.dotnet.csproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Microsoft.iOS.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net5.0-ios</TargetFramework>
     <DefineConstants>NUNITLITE_NUGET</DefineConstants>

--- a/Touch.Client/dotnet/macOS/Touch.Client-macOS.dotnet.csproj
+++ b/Touch.Client/dotnet/macOS/Touch.Client-macOS.dotnet.csproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Microsoft.macOS.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net5.0-macos</TargetFramework>
     <DefineConstants>NUNITLITE_NUGET</DefineConstants>

--- a/Touch.Client/dotnet/tvOS/Touch.Client-tvOS.dotnet.csproj
+++ b/Touch.Client/dotnet/tvOS/Touch.Client-tvOS.dotnet.csproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Microsoft.tvOS.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net5.0-tvos</TargetFramework>
     <DefineConstants>NUNITLITE_NUGET</DefineConstants>

--- a/Touch.Client/dotnet/watchOS/Touch.Client-watchOS.dotnet.csproj
+++ b/Touch.Client/dotnet/watchOS/Touch.Client-watchOS.dotnet.csproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Microsoft.watchOS.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net5.0-watchos</TargetFramework>
     <DefineConstants>NUNITLITE_NUGET</DefineConstants>


### PR DESCRIPTION
This is the desired Sdk, 'Microsoft.<platform>.Sdk' was temporary (and now we
don't need it that way anymore).