### PR TITLE
Fix C# compiler CLS-compliant warnings

### DIFF
--- a/NUnitLite/TouchRunner/TouchOptions.cs
+++ b/NUnitLite/TouchRunner/TouchOptions.cs
@@ -44,6 +44,7 @@ namespace MonoTouch.NUnit.UI {
 		NUnitV3 = 1,
 	}
 
+	[CLSCompliant (false)]
 	public class TouchOptions {
 
 		static TouchOptions current;

--- a/NUnitLite/TouchRunner/TouchRunner.cs
+++ b/NUnitLite/TouchRunner/TouchRunner.cs
@@ -679,6 +679,7 @@ namespace MonoTouch.NUnit.UI {
 		}
 	}
 
+	[CLSCompliant (false)]
 	public class TouchRunner : BaseTouchRunner {
 		
 		UIWindow window;

--- a/NUnitLite/TouchRunner/TouchViewController.cs
+++ b/NUnitLite/TouchRunner/TouchViewController.cs
@@ -30,6 +30,7 @@ using MonoTouch.Dialog;
 
 namespace MonoTouch.NUnit.UI {
 
+	[CLSCompliant (false)]
 	public partial class TouchViewController : DialogViewController {
 
 		public TouchViewController (RootElement root) : base (root, true)


### PR DESCRIPTION
```
/Users/poupou/git/xamarin/xamarin-macios/external/Touch.Unit/NUnitLite/TouchRunner/TouchRunner.cs(686,32): warning CS3001: Argument type 'UIWindow' is not CLS-compliant
/Users/poupou/git/xamarin/xamarin-macios/external/Touch.Unit/NUnitLite/TouchRunner/TouchRunner.cs(694,33): warning CS3003: Type of 'TouchRunner.NavigationController' is not CLS-compliant
/Users/poupou/git/xamarin/xamarin-macios/external/Touch.Unit/NUnitLite/TouchRunner/TouchRunner.cs(704,27): warning CS3002: Return type of 'TouchRunner.GetViewController()' is not CLS-compliant
/Users/poupou/git/xamarin/xamarin-macios/external/Touch.Unit/NUnitLite/TouchRunner/TouchOptions.cs(164,27): warning CS3002: Return type of 'TouchOptions.GetViewController()' is not CLS-compliant
/Users/poupou/git/xamarin/xamarin-macios/external/Touch.Unit/NUnitLite/TouchRunner/TouchViewController.cs(33,23): warning CS3009: 'TouchViewController': base type 'DialogViewController' is not CLS-compliant
/Users/poupou/git/xamarin/xamarin-macios/external/Touch.Unit/NUnitLite/TouchRunner/TouchViewController.cs(35,43): warning CS3001: Argument type 'RootElement' is not CLS-compliant
```