### PR TITLE
[Touch.Server] Fix parsing of -address, -port and -logpath options

### DIFF
--- a/Touch.Server/Main.cs
+++ b/Touch.Server/Main.cs
@@ -167,7 +167,7 @@ class SimpleListener {
 			{ "verbose", "Display verbose output", v => verbose = true },
 			{ "ip", "IP address to listen (default: Any)", v => address = v },
 			{ "port", "TCP port to listen (default: Any)", v => port = v },
-			{ "logpath", "Path to save the log files (default: .)", v => log_path = v },
+			{ "logpath=", "Path to save the log files (default: .)", v => log_path = v },
 			{ "logfile=", "Filename to save the log to (default: automatically generated)", v => log_file = v },
 			{ "launchdev=", "Run the specified app on a device (specify using bundle identifier)", v => launchdev = v },
 			{ "launchsim=", "Run the specified app on the simulator (specify using path to *.app directory)", v => launchsim = v },

--- a/Touch.Server/Main.cs
+++ b/Touch.Server/Main.cs
@@ -148,8 +148,8 @@ class SimpleListener {
 		
 		bool help = false;
 		bool verbose = false;
-		string address = null;
-		string port = null;
+		IPAddress ipAddress = IPAddress.Any;
+		ushort port = 0;
 		string log_path = ".";
 		string log_file = null;
 		string launchdev = null;
@@ -165,8 +165,8 @@ class SimpleListener {
 		var os = new OptionSet () {
 			{ "h|?|help", "Display help", v => help = true },
 			{ "verbose", "Display verbose output", v => verbose = true },
-			{ "ip", "IP address to listen (default: Any)", v => address = v },
-			{ "port", "TCP port to listen (default: Any)", v => port = v },
+			{ "ip=", "IP address to listen (default: Any)", v => ipAddress = IPAddress.Parse(v) },
+			{ "port=", "TCP port to listen (default: Any)", v => port = ushort.Parse(v) },
 			{ "logpath=", "Path to save the log files (default: .)", v => log_path = v },
 			{ "logfile=", "Filename to save the log to (default: automatically generated)", v => log_file = v },
 			{ "launchdev=", "Run the specified app on a device (specify using bundle identifier)", v => launchdev = v },
@@ -187,14 +187,8 @@ class SimpleListener {
 			
 			var listener = new SimpleListener ();
 			
-			IPAddress ip;
-			if (String.IsNullOrEmpty (address) || !IPAddress.TryParse (address, out ip))
-				listener.Address = IPAddress.Any;
-			
-			ushort p;
-			if (UInt16.TryParse (port, out p))
-				listener.Port = p;
-			
+			listener.Address = ipAddress;
+			listener.Port = port;
 			listener.LogPath = log_path ?? ".";
 			listener.LogFile = log_file;
 			listener.AutoExit = autoexit;

--- a/Touch.Server/Main.cs
+++ b/Touch.Server/Main.cs
@@ -165,8 +165,8 @@ class SimpleListener {
 		var os = new OptionSet () {
 			{ "h|?|help", "Display help", v => help = true },
 			{ "verbose", "Display verbose output", v => verbose = true },
-			{ "ip=", "IP address to listen (default: Any)", v => ipAddress = IPAddress.Parse(v) },
-			{ "port=", "TCP port to listen (default: Any)", v => port = ushort.Parse(v) },
+			{ "ip=", "IP address to listen (default: Any)", v => ipAddress = IPAddress.Parse (v) },
+			{ "port=", "TCP port to listen (default: Any)", v => port = ushort.Parse (v) },
 			{ "logpath=", "Path to save the log files (default: .)", v => log_path = v },
 			{ "logfile=", "Filename to save the log to (default: automatically generated)", v => log_file = v },
 			{ "launchdev=", "Run the specified app on a device (specify using bundle identifier)", v => launchdev = v },


### PR DESCRIPTION
Because the ip, port and logpath options were missing `=` at the end of their names, you couldn't actually pass any values for them. If you tried, the string values for the options would be equal to their names (rather than what the user provided), and then the parsing failures for those strings would be silently ignored.

Additionally, after the `IPAddress` was successfully parsed, we ignored the result. This resulted in `listener.Address` being null, which eventually led to a crash once the listener was started. I fixed this as well.

In addition to adding the `=` to each option, I also changed the parsing from `TryParse` to `Parse` so that invalid option values will fail with an exception. This is similar to how the `TimeSpan` options are already being handled, but I wasn't sure if it would be considered a breaking change. I just figured it's better to let the user know something is wrong vs silently ignore invalid input from them, but I can revert that change if necessary.