### PR TITLE
[TouchRunner] Try to make MacRunner exit nicely.

### DIFF
--- a/NUnitLite/TouchRunner/MacRunner.cs
+++ b/NUnitLite/TouchRunner/MacRunner.cs
@@ -36,7 +36,7 @@ namespace MonoTouch.NUnit.UI {
 						// First try to stop the app nicely. This only works if the app is showing a window.
 						app.Stop (app);
 						// Stopping the run loop only works something else is processed by the run loop, so add an event.
-						app.PostEvent (NSEvent.OtherEvent (NSEventType.ApplicationDefined, CoreGraphics.CGPoint.Empty, (NSEventModifierMask) 0, 0, 0, null, 0, 0, 0), true);
+						app.PostEvent (NSEvent.OtherEvent (NSEventType.ApplicationDefined, CGPoint.Empty, (NSEventModifierMask) 0, 0, 0, null, 0, 0, 0), true);
 						// And try something else too in case the application-defined event doesn't work.
 						app.AbortModal ();
 					});


### PR DESCRIPTION
Try to exit the NSApplication run loop nicely, by calling NSApplication.Stop.
The problem is that there seems to be certain requirements for stopping the
NSApplication: one being that apparently there must be a window around. So
create a window (that shows up in the background). Then at the end we have to
post something to the event loop after calling Stop (because calling Stop
apparently only sets a flag that's checked after processing an event). And
just in case seomthing goes wrong, try two different ways of posting events to
the event loop.