### PR TITLE
[Touch.Client] There's no need to include Xamarin.iOS in Mac Catalyst projects.

### DIFF
--- a/Touch.Client/dotnet/MacCatalyst/Touch.Client-MacCatalyst.dotnet.csproj
+++ b/Touch.Client/dotnet/MacCatalyst/Touch.Client-MacCatalyst.dotnet.csproj
@@ -61,6 +61,5 @@
     <PackageReference Include="NUnit.Extension.NUnitV2ResultWriter">
       <Version>3.6.0</Version>
     </PackageReference>
-    <Reference Include="Xamarin.iOS" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
It's done automatically now.