### PR TITLE
[TouchRunner] Use CFString.FromHandle instead of NSString.FromHandle.

### DIFF
--- a/NUnitLite/TouchRunner/TouchRunner.cs
+++ b/NUnitLite/TouchRunner/TouchRunner.cs
@@ -30,6 +30,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
+using CoreFoundation;
 using Foundation;
 using ObjCRuntime;
 #if !__MACOS__
@@ -879,7 +880,7 @@ namespace MonoTouch.NUnit.UI {
 			get {
 				IntPtr handle = UIDevice.CurrentDevice.Handle;
 				if (UIDevice.CurrentDevice.RespondsToSelector (new Selector ("uniqueIdentifier")))
-					return NSString.FromHandle (objc_msgSend (handle, Selector.GetHandle("uniqueIdentifier")));
+					return CFString.FromHandle (objc_msgSend (handle, Selector.GetHandle("uniqueIdentifier")));
 				return "unknown";
 			}
 		}


### PR DESCRIPTION
Fixes this compiler warning:

> warning CS0618: 'NSString.FromHandle(IntPtr)' is obsolete: 'Use of 'CFString.FromHandle' offers better performance.'