### PR TITLE
[MacRunner] Add availability attribute to avoid a compiler warning.

### DIFF
--- a/NUnitLite/TouchRunner/MacRunner.cs
+++ b/NUnitLite/TouchRunner/MacRunner.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
+using System.Runtime.Versioning;
 using System.Threading.Tasks;
 
 using AppKit;
@@ -9,6 +10,9 @@ using Foundation;
 using CoreGraphics;
 
 namespace MonoTouch.NUnit.UI {
+#if NET
+	[SupportedOSPlatform ("macos10.11")]
+#endif
 	public class MacRunner : BaseTouchRunner {
 		// The exitProcess callback must not return. The boolean parameter specifies whether the test run succeeded or not.
 		public static async Task<int> MainAsync (IList<string> arguments, bool requiresNSApplicationRun, Action<int> exitProcess, params Assembly[] assemblies)

--- a/NUnitLite/TouchRunner/MacRunner.cs
+++ b/NUnitLite/TouchRunner/MacRunner.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
-using System.Runtime.Versioning;
 using System.Threading.Tasks;
 
 using AppKit;
@@ -10,9 +9,6 @@ using Foundation;
 using CoreGraphics;
 
 namespace MonoTouch.NUnit.UI {
-#if NET
-	[SupportedOSPlatform ("macos10.11")]
-#endif
 	public class MacRunner : BaseTouchRunner {
 		// The exitProcess callback must not return. The boolean parameter specifies whether the test run succeeded or not.
 		public static async Task<int> MainAsync (IList<string> arguments, bool requiresNSApplicationRun, Action<int> exitProcess, params Assembly[] assemblies)

--- a/NUnitLite/TouchRunner/TouchRunner.cs
+++ b/NUnitLite/TouchRunner/TouchRunner.cs
@@ -27,6 +27,7 @@ using System.Net.Sockets;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -59,6 +60,13 @@ using NUnit.Framework.Internal.WorkItems;
 using SettingsDictionary = System.Collections.Generic.IDictionary<string, object>;
 #else
 using SettingsDictionary = System.Collections.IDictionary;
+#endif
+
+#if NET
+[assembly: SupportedOSPlatform ("ios10.0")]
+[assembly: SupportedOSPlatform ("tvos10.0")]
+[assembly: SupportedOSPlatform ("macos10.14")]
+[assembly: SupportedOSPlatform ("maccatalyst13.0")]
 #endif
 
 namespace MonoTouch.NUnit.UI {


### PR DESCRIPTION
Fixes this warning:

    xamarin-macios/tests/common/mac/MacMain.cs(24,26): warning CA1416: This call site is reachable on: 'macOS/OSX' 10.11 and later. 'MacRunner.MainAsync(IList<string>, bool, Action<int>, params Assembly[])' is only supported on: 'macOS/OSX' 12.0 and later.