### PR TITLE
[Touch.Client] Use 'BundledNETCoreAppTargetFrameworkVersion' to specify the .NET version in the project files.

### DIFF
--- a/Touch.Client/dotnet/MacCatalyst/Touch.Client-MacCatalyst.dotnet.csproj
+++ b/Touch.Client/dotnet/MacCatalyst/Touch.Client-MacCatalyst.dotnet.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-maccatalyst</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-maccatalyst</TargetFramework>
   </PropertyGroup>
   <Import Project="../shared.csproj" />
 </Project>

--- a/Touch.Client/dotnet/iOS/Touch.Client-iOS.dotnet.csproj
+++ b/Touch.Client/dotnet/iOS/Touch.Client-iOS.dotnet.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-ios</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
   </PropertyGroup>
   <Import Project="../shared.csproj" />
 </Project>

--- a/Touch.Client/dotnet/macOS/Touch.Client-macOS.dotnet.csproj
+++ b/Touch.Client/dotnet/macOS/Touch.Client-macOS.dotnet.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-macos</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-macos</TargetFramework>
   </PropertyGroup>
   <Import Project="../shared.csproj" />
 </Project>

--- a/Touch.Client/dotnet/tvOS/Touch.Client-tvOS.dotnet.csproj
+++ b/Touch.Client/dotnet/tvOS/Touch.Client-tvOS.dotnet.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-tvos</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-tvos</TargetFramework>
     <!-- Currently, NuGet is not able to restore existing Xamarin.TVOS packages for a .NET 5 project, so use AssetTargetFallback to tell NuGet that the existing packages work -->
     <AssetTargetFallback>xamarintvos10;$(AssetTargetFallback)</AssetTargetFallback>
   </PropertyGroup>


### PR DESCRIPTION
This way we'll target net6.0-* when building with .NET 6, and net7.0-* when
building with .NET 7.