### PR TITLE
Revert "[Touch.Client] Use 'BundledNETCoreAppTargetFrameworkVersion' to specify the .NET version in the project files. (#113)"

### DIFF
--- a/Touch.Client/dotnet/MacCatalyst/Touch.Client-MacCatalyst.dotnet.csproj
+++ b/Touch.Client/dotnet/MacCatalyst/Touch.Client-MacCatalyst.dotnet.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-maccatalyst</TargetFramework>
+    <TargetFramework>net6.0-maccatalyst</TargetFramework>
   </PropertyGroup>
   <Import Project="../shared.csproj" />
 </Project>

--- a/Touch.Client/dotnet/iOS/Touch.Client-iOS.dotnet.csproj
+++ b/Touch.Client/dotnet/iOS/Touch.Client-iOS.dotnet.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
+    <TargetFramework>net6.0-ios</TargetFramework>
   </PropertyGroup>
   <Import Project="../shared.csproj" />
 </Project>

--- a/Touch.Client/dotnet/macOS/Touch.Client-macOS.dotnet.csproj
+++ b/Touch.Client/dotnet/macOS/Touch.Client-macOS.dotnet.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-macos</TargetFramework>
+    <TargetFramework>net6.0-macos</TargetFramework>
   </PropertyGroup>
   <Import Project="../shared.csproj" />
 </Project>

--- a/Touch.Client/dotnet/tvOS/Touch.Client-tvOS.dotnet.csproj
+++ b/Touch.Client/dotnet/tvOS/Touch.Client-tvOS.dotnet.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-tvos</TargetFramework>
+    <TargetFramework>net6.0-tvos</TargetFramework>
     <!-- Currently, NuGet is not able to restore existing Xamarin.TVOS packages for a .NET 5 project, so use AssetTargetFallback to tell NuGet that the existing packages work -->
     <AssetTargetFallback>xamarintvos10;$(AssetTargetFallback)</AssetTargetFallback>
   </PropertyGroup>


### PR DESCRIPTION
This reverts commit be3a8d0855b8291848d02c9c9d99748cb41c56c2.

It won't be needed, using 'net6.0-*' will continue to work in .NET 7+.