### PR TITLE
Always use NUnitTestAssemblyRunner's Load overload with the assembly name

### DIFF
--- a/NUnitLite/TouchRunner/TouchRunner.cs
+++ b/NUnitLite/TouchRunner/TouchRunner.cs
@@ -166,7 +166,7 @@ namespace MonoTouch.NUnit.UI {
 		public void LoadSync ()
 		{
 			foreach (Assembly assembly in assemblies)
-				Load (assembly);
+				Load (assembly.GetName().Name);
 			assemblies.Clear ();
 		}
 


### PR DESCRIPTION
This PR adds a workaround to support NativeAOT runtime with Xamarin.

### Introduction
The limitation comes from the unsupported or limited support for the following properties on `Assembly` type with NativeAOT
- `CodeBase` - unsupported feature - throws with: https://github.com/dotnet/runtime/blob/588dcd7a29f109daae2d8c999322acd8e853a8c6/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/General/ThunkedApis.cs#L70-L78
- `Location` - somewhat supported - empty string: https://github.com/dotnet/runtime/blob/588dcd7a29f109daae2d8c999322acd8e853a8c6/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/General/ThunkedApis.cs#L66

Both properties do not seem to make sense with NativeAOT, as the assembly is not preserved in its original format.
These limitations prevent using NUnitTestAssemblyRunner's Load overload which accepts `Assembly` object as parameter, which is discussed in the tracking issue: https://github.com/xamarin/xamarin-macios/issues/17774

### Changes
The included change, changes the way the `TestSuite` is created by NUnit framework for all runtimes. 
This affects the created name of test suites in the following way e.g.,:
- `monotouchtest.dll` -> `monotouchtest`
- `EmbeddedResources.dll` -> `EmbeddedResources`
- ...etc

The change has been tested locally with monotouch-test running on iOS device using .NET7 mono runtime 

---
Fixes: https://github.com/xamarin/xamarin-macios/issues/17774

/cc: @rolfbjarne 