### PR TITLE
Second attempt to use NUnitTestAssemblyRunner's Load overload with the assembly name

### DIFF
--- a/NUnitLite/TouchRunner/TouchRunner.cs
+++ b/NUnitLite/TouchRunner/TouchRunner.cs
@@ -166,7 +166,7 @@ namespace MonoTouch.NUnit.UI {
 		public void LoadSync ()
 		{
 			foreach (Assembly assembly in assemblies)
-				Load (assembly.GetName().Name);
+				Load (assembly);
 			assemblies.Clear ();
 		}
 
@@ -603,9 +603,7 @@ namespace MonoTouch.NUnit.UI {
 
 		public bool Load (Assembly assembly, IDictionary<string, object> settings = null)
 		{
-			var runner = new NUnitTestAssemblyRunner (builder);
-			runners.Add (runner);
-			return AddSuite ((TestSuite) runner.Load (assembly, CreateSettings (settings)));
+			return Load (assembly.GetName ().Name, settings);
 		}
 #else
 		NUnitLiteTestAssemblyBuilder builder = new NUnitLiteTestAssemblyBuilder ();


### PR DESCRIPTION
Due to legacy Xamarin test failures: https://github.com/xamarin/xamarin-macios/pull/17819#issuecomment-1479549660
The change should only affect tests and code paths which are using NUnit nuget package.

Related to: https://github.com/spouliot/Touch.Unit/pull/116 